### PR TITLE
fix(onChange fn): comply with angular-material $mdDialog

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -377,7 +377,7 @@
             var valChange = (newVal !== oldVal || typeof stickyLine === 'undefined');
             var notSticking = (!isSticking && !isBottomedOut());
 
-            if (valChange && notSticking && newVal !== 0 && elemIsShowed) {
+            if (valChange && notSticking && newVal > 0 && elemIsShowed) {
               stickyLine = newVal - offset;
               //Update dimensions of sticky element when is showed
               if (elemIsShowed && elemWasHidden) {


### PR DESCRIPTION
This fixes the stuck element's behaviour when used together with angular-material's $mdDialog service. When a dialog is shown, angular-material changes "position" and "top" properties of the "body" element for the time when popup is visible. This brakes "onChange" fn's calculations of the sticky line which tells ngStickhy when to "un-stick" the sticky element when user scrolls back up.
